### PR TITLE
Mobile: footer link typography + regression test

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -1,11 +1,13 @@
 <!-- <a target="_blank" href="{{ site.user.email.send }}"> Email</a> &nbsp;/&nbsp; -->
 
-{% if site.user.cv %}<a href="{{ site.user.cv }}">CV</a><span class="sep"> / </span>{% endif %}
-<a href="{{ site.user.scholar | prepend: 'https://scholar.google.com/citations?user=' }}">Google Scholar</a><span class="sep"> / </span>
-{% if site.user.publications %}<a href="{{ site.user.publications }}">Publications</a><span class="sep"> / </span>{% endif %}
-<a href="{{ site.user.github | prepend: 'https://github.com/' }}">GitHub</a><span class="sep"> / </span>
-<!-- <a href="{{ site.user.notebook }}">Notebook</a> <span class="sep"> / </span> -->
-<a href="{{ site.user.linkedin | prepend: 'https://www.linkedin.com/in/' }}">LinkedIn</a><span class="sep"> / </span>
-<a href="{{ site.user.amazon | prepend: 'https://www.amazon.com/stores/author/' }}">Amazon Books</a>
+<div class="primary-links">
+  {% if site.user.cv %}<a href="{{ site.user.cv }}">CV</a><span class="sep"> / </span>{% endif %}
+  <a href="{{ site.user.scholar | prepend: 'https://scholar.google.com/citations?user=' }}">Google Scholar</a><span class="sep"> / </span>
+  {% if site.user.publications %}<a href="{{ site.user.publications }}">Publications</a><span class="sep"> / </span>{% endif %}
+  <a href="{{ site.user.github | prepend: 'https://github.com/' }}">GitHub</a><span class="sep"> / </span>
+  <!-- <a href="{{ site.user.notebook }}">Notebook</a> <span class="sep"> / </span> -->
+  <a href="{{ site.user.linkedin | prepend: 'https://www.linkedin.com/in/' }}">LinkedIn</a><span class="sep"> / </span>
+  <a href="{{ site.user.amazon | prepend: 'https://www.amazon.com/stores/author/' }}">Amazon Books</a>
+</div>
 
 

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -32,9 +32,9 @@
   .intro-photo { order: -1; width: 100% !important; max-width: none !important; }
   .intro-bio { order: 1; width: 100% !important; max-width: none !important; }
 
-  /* Make primary links easier to tap; remove separators. */
-  .sep { display: none; }
-  p a {
+  /* Make footer links easier to tap (without styling inline links in the bio). */
+  .primary-links .sep { display: none; }
+  .primary-links a {
     display: inline-block;
     padding: 10px 12px;
     margin: 6px 4px;

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -32,15 +32,20 @@
   .intro-photo { order: -1; width: 100% !important; max-width: none !important; }
   .intro-bio { order: 1; width: 100% !important; max-width: none !important; }
 
-  /* Make footer links easier to tap (without styling inline links in the bio). */
-  .primary-links .sep { display: none; }
+  /* Footer links: keep typography consistent with body; only rely on color.
+     Improve tap-ability via line-height + light padding (no pill/button styling). */
+  .primary-links {
+    line-height: 2.0;
+    text-align: center;
+  }
+
   .primary-links a {
-    display: inline-block;
-    padding: 10px 12px;
-    margin: 6px 4px;
-    border: 1px solid rgba(7, 136, 155, 0.35);
-    border-radius: 999px;
-    line-height: 1;
+    font-size: inherit;
+    font-family: inherit;
+    display: inline;
+    padding: 4px 2px;
+    margin: 0 6px;
+    white-space: nowrap;
   }
 
 }

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require('@playwright/test');
 test.describe('home page mobile layout', () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
-  test('avatar centered and bio left-aligned; lucky button right aligned', async ({ page, baseURL }) => {
+  test('avatar centered and bio left-aligned; lucky button right aligned; footer links match body typography', async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/`);
 
     const photo = page.locator('.profile-photo');
@@ -25,5 +25,34 @@ test.describe('home page mobile layout', () => {
       .locator('.lucky-wrapper')
       .evaluate((el) => getComputedStyle(el).textAlign);
     expect(luckyAlign).toBe('right');
+
+    // Footer links should look like normal text links (not pill buttons).
+    const bodyTypography = await page.evaluate(() => {
+      const s = getComputedStyle(document.body);
+      return { fontFamily: s.fontFamily, fontSize: s.fontSize, fontWeight: s.fontWeight };
+    });
+
+    const footerLinkTypography = await page.locator('.primary-links a').first().evaluate((el) => {
+      const s = getComputedStyle(el);
+      return {
+        fontFamily: s.fontFamily,
+        fontSize: s.fontSize,
+        fontWeight: s.fontWeight,
+        borderRadius: s.borderRadius,
+        borderStyle: s.borderStyle,
+        backgroundColor: s.backgroundColor,
+        display: s.display
+      };
+    });
+
+    expect(footerLinkTypography.fontFamily).toBe(bodyTypography.fontFamily);
+    expect(footerLinkTypography.fontSize).toBe(bodyTypography.fontSize);
+    expect(footerLinkTypography.fontWeight).toBe(bodyTypography.fontWeight);
+
+    // Ensure we didn't regress to the previous pill/button look.
+    expect(footerLinkTypography.display).toBe('inline');
+    expect(footerLinkTypography.borderStyle).toBe('none');
+    expect(footerLinkTypography.borderRadius).toBe('0px');
+    expect(footerLinkTypography.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   });
 });


### PR DESCRIPTION
Follow-up mobile tweaks:\n- Footer links use same typography as body (only color differs)\n- Add Playwright regression assertion to prevent pill/button link styling\n\n(Previous PR #7 was merged before these follow-up commits.)