### PR TITLE
Test: add npm script to run Playwright e2e (auto-start Jekyll)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,33 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Node deps
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "playwright test",
     "test:headed": "playwright test --headed",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "test:e2e": "bash scripts/test_e2e.sh"
   },
   "devDependencies": {
     "@playwright/test": "^1.45.0"

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Prefer brew ruby@3.2 on macOS when available.
+if [ -d "/opt/homebrew/opt/ruby@3.2/bin" ]; then
+  export PATH="/opt/homebrew/opt/ruby@3.2/bin:$PATH"
+fi
+
+# Avoid Jekyll/Sass encoding issues.
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
+PORT="${PORT:-4000}"
+HOST="${HOST:-127.0.0.1}"
+BASE_URL="${BASE_URL:-http://${HOST}:${PORT}}"
+
+bundle config set path vendor/bundle >/dev/null
+bundle install --quiet
+
+# Start Jekyll.
+(bundle exec jekyll serve --host "$HOST" --port "$PORT" --quiet & echo $! > /tmp/jekyll_pid)
+
+# Wait for server.
+for _ in $(seq 1 80); do
+  if curl -fsS "$BASE_URL/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+
+npm ci --silent
+BASE_URL="$BASE_URL" npx playwright test
+
+# Stop server.
+kill "$(cat /tmp/jekyll_pid)" 2>/dev/null || true
+rm -f /tmp/jekyll_pid


### PR DESCRIPTION
Adds scripts/test_e2e.sh and `npm run test:e2e` so Playwright tests run without manually starting Jekyll first.\n\n- Uses brew ruby@3.2 if present on macOS\n- Sets LANG/LC_ALL to UTF-8 to avoid SCSS encoding issues