### PR TITLE
Docs: add local dev script + Ruby/UTF-8 notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ Playwright end-to-end tests cover the reading page behaviors (language switching
 You can run headed or UI mode with `npm run test:headed` or `npm run test:ui`.
 
 CI: GitHub Actions (`.github/workflows/ci.yml`) builds the site, serves `_site` on port 4000, installs Playwright browsers, and runs the Playwright suite on every push/PR.
+
+## Local development
+
+On macOS, the system Ruby can be too old for the repo's locked bundler and may cause gem install issues.
+
+Recommended setup:
+
+- Install Ruby 3.2: `brew install ruby@3.2`
+- Run the dev server: `bash scripts/dev.sh`
+
+Notes:
+- We set `LANG/LC_ALL` to UTF-8 in scripts to avoid intermittent Sass/SCSS encoding errors.
+- E2E tests can be run with: `npm run test:e2e` (auto-starts Jekyll).

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Prefer brew ruby@3.2 on macOS when available.
+if [ -d "/opt/homebrew/opt/ruby@3.2/bin" ]; then
+  export PATH="/opt/homebrew/opt/ruby@3.2/bin:$PATH"
+fi
+
+# Avoid Jekyll/Sass encoding issues.
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
+bundle config set path vendor/bundle >/dev/null
+bundle install --quiet
+
+bundle exec jekyll serve --host 127.0.0.1 --port 4000


### PR DESCRIPTION
Adds scripts/dev.sh and README notes so local Jekyll dev is repeatable (esp. on macOS where system Ruby is old).