### PR TITLE
Add blog page: The Real Flywheel

### DIFF
--- a/writing/the-real-flywheel/index.html
+++ b/writing/the-real-flywheel/index.html
@@ -1,0 +1,174 @@
+---
+layout: null
+---
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-R7BNJ90QEW"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);} 
+    gtag('js', new Date());
+    gtag('config', 'G-R7BNJ90QEW');
+  </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>The Real Flywheel | {{ site.title }}</title>
+  <meta name="description" content="A note on why the key bottleneck in frontier AI is effective datapoint throughput, and why agent-accelerated infra is the real flywheel.">
+  <link rel="shortcut icon" href="{{ site.favicon }}" type="image/vnd.microsoft.icon">
+  <link rel="stylesheet" href="/assets/css/styles.css">
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+  <style>
+    .essay-page { background: #f8f9fb; min-height: 100vh; padding: 40px 16px; }
+    .essay-wrap { max-width: 820px; margin: 0 auto; }
+    .essay-card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
+      padding: 28px;
+    }
+    .essay-top { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; margin-bottom: 14px; }
+    .essay-title { margin: 0; font-size: 30px; line-height: 1.2; color: #111827; text-align: left; }
+    .essay-meta { color: #6b7280; font-size: 14px; }
+    .essay-content h2, .essay-content h3 { display: block; margin: 26px 0 10px; color: #111827; }
+    .essay-content h2 { font-size: 24px; font-weight: 700; }
+    .essay-content h3 { font-size: 19px; font-weight: 700; }
+    .essay-content p { margin: 0 0 14px; color: #1f2937; }
+    .essay-content ul { margin: 0 0 14px 20px; }
+    .essay-content li { margin-bottom: 6px; color: #1f2937; }
+    .essay-content blockquote {
+      margin: 12px 0 16px;
+      padding: 8px 14px;
+      border-left: 3px solid #07889b;
+      background: #f7fbfc;
+      color: #0f172a;
+      font-style: italic;
+    }
+    .essay-content .formula {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: #f3f4f6;
+      border-radius: 8px;
+      padding: 10px 12px;
+      overflow-x: auto;
+    }
+    .essay-content details {
+      border-top: 1px solid #e5e7eb;
+      margin-top: 24px;
+      padding-top: 16px;
+    }
+    .essay-content summary { cursor: pointer; color: #07889b; margin-bottom: 12px; }
+    @media (max-width: 600px) {
+      .essay-card { padding: 20px; }
+      .essay-title { font-size: 26px; }
+      .essay-top { flex-direction: column; align-items: flex-start; }
+    }
+  </style>
+</head>
+
+<body class="essay-page">
+  <div class="essay-wrap">
+    <article class="essay-card essay-content">
+      <div class="essay-top">
+        <a class="reading-back" href="/">&larr; Back home</a>
+        <div class="essay-meta">Feb 7, 2026 • Draft note</div>
+      </div>
+
+      <h1 class="essay-title">The Real Flywheel</h1>
+      <p><strong>TL;DR:</strong> A flywheel that needs humans to spin it is a treadmill. A coding agent is not.</p>
+
+      <p>Almost a year ago, right after my post-training team shipped several major GPT‑4o updates, I felt exhausted — excited, but oddly disoriented.</p>
+      <p>This was March 2025. DAU looked great. The holdout set showed a 6%+ lift. In any normal product org, that’s champagne.</p>
+      <p>And we had, in a sense, found what search / recommendation / ads people have always treated as the holy grail: a large user base; a plausible story for turning behavior into training signal; and a crew of MLEs who could stack endless small wins until the metrics moved.</p>
+      <p>But it still wasn’t AGI. It was the old comfortable paradigm. The wins didn’t compound into a capability jump; the curve could flatten at any moment.</p>
+      <p>It felt like raising a digient in <em>The Lifecycle of Software Objects</em> — they keep getting better, but they don’t grow up.</p>
+      <p>That realization drained me. I started looking for a different kind of work.</p>
+      <p>This post is what I found over the next 12 months — and the prediction it left me with.</p>
+
+      <h3>Some Flywheels</h3>
+      <p>In search / recs / ads, the canonical flywheel is: you ship, users show up, behavior becomes signal, the model improves, and you ship again.</p>
+      <p>At scale, the user base is not only the prize — it’s inertia. Data stops feeling like fuel and starts acting like stored momentum: you bank it, and you spend it to move faster.</p>
+      <p>Autonomous driving was the same story with different nouns: miles become edge cases; edge cases become autonomy; autonomy buys more miles.</p>
+
+      <h3>The Real Flywheel</h3>
+      <p>A flywheel that needs humans to spin it is a treadmill.</p>
+      <p>With humans in the loop, iteration speed is capped by meetings, reviews, coordination, and the tiny number of changes you can safely push at once.</p>
+      <p>A/B testing is the slowest version of this: you burn millions of interactions to buy one decision. Even “better” loops — CTR/CVR models, implicit feedback training — are still downstream of UI exposure and confounders. The signal is real, but it’s shaped by humans at every step.</p>
+      <p>The real question is stricter:</p>
+      <blockquote>Can we turn ideas into clean, attributable evidence on demand — repeatedly — without a human ceremony layer each time?</blockquote>
+      <p>If you’ve used Codex / Claude Code seriously, you can feel the first crack in the treadmill. Once enough engineers believe agents are real, the loop starts closing on itself.</p>
+
+      <h3>Data Point and Researcher</h3>
+      <p>My mental model is blunt: if you have enough experimental datapoints, even an okay researcher will find the manifold.</p>
+      <p>With 10× more datapoints, an average PhD can look like Ilya. With 10^5× more datapoints, a strong agent can start to look like a serious researcher.</p>
+      <p>Not because theory stops mattering, but because a lot of frontier work sits uncomfortably close to the empirical end of the spectrum: you learn by trying.</p>
+      <p>And a “datapoint” here is not a single training example. It’s an end-to-end belief update produced by a long rollout of humans, GPUs, and org structure — from data center capacity to an experiment proposal, data plumbing, training runs, babysitting failures, and writing the Slack post.</p>
+      <p>A clean ablation. A failure with a named failure mode and a concrete fix. A new eval slice that exposes a blind spot. An online signal you can trace back to a capability.</p>
+      <p>I don’t buy that idea supply is the bottleneck in frontier labs. GPU supply isn’t either — money can buy more GPUs (and hire brains).</p>
+      <p>The bottleneck is how fast you can convert an idea into a high‑signal datapoint — and then do it again.</p>
+      <p>When people say “AI improves itself,” the first thing that happens is probably not AI proposing one brilliant idea that reshapes the landscape. It’s a boring multiplier: more attempts per unit time, per GPU, per researcher, per engineer.</p>
+      <p>Genius shifts the distribution. Agent‑accelerated infrastructure increases the number of draws.</p>
+
+      <h3>RL Infra 2026</h3>
+      <p>We are <a href="https://ai-2027.com/#narrative-2026-04-30">here</a> in the AI‑2027 narrative. And people still hear “RL infra” and picture train/eval plumbing.</p>
+      <p>That’s table stakes.</p>
+      <p>What I mean is the system that manufactures effective datapoints with minimal human intervention. I think this is already starting to happen with tools like Codex. For the first time, the tool isn’t just a wrench. It can carry intent across steps.</p>
+      <p>Infrastructure used to be like a lathe: rigid, purpose-built, expensive to change. Increasingly it wants to look like an iPhone: a general platform you keep reshaping — by adding apps — as your needs change. And the installation of apps is smoother and smoother.</p>
+      <p>If 2025 was about shipping model updates, then 2026 is about making the loop run by itself.</p>
+      <p>Some friends in GDM keep saying they’re doing “best‑of‑N.” I want to say: N now includes the agents.</p>
+
+      <details>
+        <summary>Draft notes / appendix</summary>
+
+        <p><strong>Thesis:</strong> In frontier AI, the bottleneck is rarely how many ideas we can generate. The bottleneck is how fast we can turn an idea into a high‑signal datapoint — and do it repeatedly.</p>
+        <p>Iteration speed (even “dumb trial-and-error”) is a first-order competitive advantage. The labs that win can run more closed loops per unit time, with less org friction and higher signal quality.</p>
+
+        <h3>1) What counts as a datapoint?</h3>
+        <ul>
+          <li>Ablation results (what changed, how much, and with what confidence)</li>
+          <li>A failed run with a clear failure mode and corrective action</li>
+          <li>A new evaluation slice that reveals a blind spot</li>
+          <li>Online user feedback traceable to a capability</li>
+          <li>A safety/policy regression that is caught and localized</li>
+        </ul>
+
+        <h3>2) Effective datapoints = throughput × signal</h3>
+        <div class="formula">Let q_i ∈ [0, 1] be information quality of datapoint i.<br>
+          D_eff = Σ q_i ≈ N · q̄<br><br>
+          N = T / τ<br>
+          T = time window (e.g. one week)<br>
+          τ = cycle time from idea → experiment → result → attribution → next step
+        </div>
+        <p>Frontier advantage often comes from an order-of-magnitude reduction in τ, not a 10–20% improvement.</p>
+
+        <h3>3) Decomposition (where bottlenecks hide)</h3>
+        <div class="formula">D_eff ≈ GPU_throughput × Human_throughput × Automation_multiplier × Signal_quality × Org_friction^{-1}</div>
+        <ul>
+          <li><strong>GPU throughput:</strong> scheduling, queue time, utilization, failure waste</li>
+          <li><strong>Human throughput:</strong> implementation speed, glue-work burden, review latency</li>
+          <li><strong>Automation multiplier:</strong> agents + infra compress cycle time</li>
+          <li><strong>Signal quality:</strong> reproducible, attributable, comparable, auditable</li>
+          <li><strong>Org friction:</strong> permissions, alignment overhead, unclear ownership</li>
+        </ul>
+
+        <h3>4) Why more attempts matters</h3>
+        <p>If idea supply is not the bottleneck, then faster sampling of the idea manifold dominates. In long-tailed domains, increasing the number of attempts can materially improve the best observed outcome.</p>
+
+        <h3>5) The real flywheel: model capability ↔ infra automation</h3>
+        <ul>
+          <li>Better models → better agents</li>
+          <li>Better agents → more automation</li>
+          <li>More automation → shorter τ and higher q̄</li>
+          <li>Shorter τ + higher q̄ → more effective datapoints</li>
+          <li>More effective datapoints → faster discovery</li>
+          <li>Faster discovery → better models</li>
+        </ul>
+
+        <p><strong>Closing:</strong> The frontier is not only a competition of models — it’s a competition of feedback systems. GPUs are energy, researchers provide direction, and infra/agents convert energy into information.</p>
+      </details>
+    </article>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add a new standalone blog page at `/writing/the-real-flywheel/`
- import and format content from the Notion draft **The Real Flywheel**
- preserve existing site styling by reusing current CSS and layout conventions (`layout: null` page like `reading/`)
- include a collapsible appendix for draft notes/formulas

## Validation
- `bundle exec jekyll build`
- `./scripts/test_e2e.sh` (7 passing)

## Preview
- Local: `http://127.0.0.1:4000/writing/the-real-flywheel/`
- Production (after merge): `https://hsheng.org/writing/the-real-flywheel/`
