### PR TITLE
Style: unify TL;DR + link typography in The Real Flywheel

### DIFF
--- a/writing/the-real-flywheel/index.html
+++ b/writing/the-real-flywheel/index.html
@@ -37,6 +37,17 @@ layout: null
     .essay-content h3 { font-size: 22px; font-weight: 700; }
     .essay-content h4 { font-size: 19px; font-weight: 700; }
     .essay-content p { margin: 0 0 18px; color: #1f2937; font-size: 20px; line-height: 1.82; letter-spacing: 0.005em; }
+    .tldr-line, .tldr-line strong {
+      font-family: inherit;
+      font-style: normal;
+    }
+    .essay-content a,
+    .essay-content a:visited,
+    .essay-content a em,
+    .essay-content a strong {
+      font-family: inherit;
+      font-style: inherit;
+    }
     .essay-content ul, .essay-content ol { margin: 0 0 18px 24px; }
     .essay-content li { margin-bottom: 10px; color: #1f2937; font-size: 19px; line-height: 1.72; }
     .essay-content blockquote {
@@ -112,7 +123,7 @@ layout: null
       </div>
 
       <h1 class="essay-title">The Real Flywheel</h1>
-      <p><strong>TL;DR:</strong> A flywheel that needs humans to spin it is a treadmill. A coding agent is not.</p>
+      <p class="tldr-line"><strong>TL;DR:</strong> A flywheel that needs humans to spin it is a treadmill. A coding agent is not.</p>
 
       <p>Almost a year ago, right after my post-training team shipped several major GPT‑4o updates, I felt exhausted — excited, but oddly disoriented.</p>
       <p>This was March 2025. DAU looked great. The holdout set showed a 6%+ lift. In any normal product org, that’s champagne.</p>

--- a/writing/the-real-flywheel/index.html
+++ b/writing/the-real-flywheel/index.html
@@ -129,7 +129,7 @@ layout: null
       <p>This was March 2025. DAU looked great. The holdout set showed a 6%+ lift. In any normal product org, that’s champagne.</p>
       <p>And we had, in a sense, found what search / recommendation / ads people have always treated as the holy grail: a large user base; a plausible story for turning behavior into training signal; and a crew of MLEs who could stack endless small wins until the metrics moved.</p>
       <p>But it still wasn’t AGI. It was the old comfortable paradigm. The wins didn’t compound into a capability jump; the curve could flatten at any moment.</p>
-      <p>It felt like raising a <a href="https://en.wikipedia.org/wiki/The_Lifecycle_of_Software_Objects"><em>digient in The Lifecycle of Software Objects</em></a> — they keep getting better, but they don’t grow up.</p>
+      <p>It felt like raising a <a href="https://en.wikipedia.org/wiki/The_Lifecycle_of_Software_Objects">digient in The Lifecycle of Software Objects</a> — they keep getting better, but they don’t grow up.</p>
       <p>That realization drained me. I started looking for a different kind of work.</p>
       <p>This post is what I found over the next 12 months — and the prediction it left me with.</p>
 


### PR DESCRIPTION
Small typography polish for /writing/the-real-flywheel/:\n\n- keep TL;DR line in the same article font\n- make hyperlink typography consistent with body text (no italic mismatch)\n\nThis addresses the latest font consistency feedback.