### PR TITLE
Style: fix Lifecycle link scope and size consistency

### DIFF
--- a/writing/the-real-flywheel/index.html
+++ b/writing/the-real-flywheel/index.html
@@ -52,6 +52,9 @@ layout: null
     .essay-content a strong {
       font-family: inherit;
       font-style: inherit;
+      font-size: inherit;
+      line-height: inherit;
+      font-weight: inherit;
     }
     .essay-content ul, .essay-content ol { margin: 0 0 18px 24px; }
     .essay-content li { margin-bottom: 10px; color: #1f2937; font-size: 19px; line-height: 1.72; }
@@ -144,7 +147,7 @@ layout: null
       <p>This was March 2025. DAU looked great. The holdout set showed a 6%+ lift. In any normal product org, that’s champagne.</p>
       <p>And we had, in a sense, found what search / recommendation / ads people have always treated as the holy grail: a large user base; a plausible story for turning behavior into training signal; and a crew of MLEs who could stack endless small wins until the metrics moved.</p>
       <p>But it still wasn’t AGI. It was the old comfortable paradigm. The wins didn’t compound into a capability jump; the curve could flatten at any moment.</p>
-      <p>It felt like raising a <a href="https://en.wikipedia.org/wiki/The_Lifecycle_of_Software_Objects">digient in The Lifecycle of Software Objects</a> — they keep getting better, but they don’t grow up.</p>
+      <p>It felt like raising a digient in <a href="https://en.wikipedia.org/wiki/The_Lifecycle_of_Software_Objects">The Lifecycle of Software Objects</a> — they keep getting better, but they don’t grow up.</p>
       <p>That realization drained me. I started looking for a different kind of work.</p>
       <p>This post is what I found over the next 12 months — and the prediction it left me with.</p>
 


### PR DESCRIPTION
- only keep hyperlink on "The Lifecycle of Software Objects"\n- ensure link typography inherits body size/line-height/weight for consistency