### PR TITLE
Add reusable comments section for writing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ You can run headed or UI mode with `npm run test:headed` or `npm run test:ui`.
 
 CI: GitHub Actions (`.github/workflows/ci.yml`) builds the site, serves `_site` on port 4000, installs Playwright browsers, and runs the Playwright suite on every push/PR.
 
+## Writing comments (Disqus)
+
+`writing/the-real-flywheel/index.html` now includes a reusable comments block via:
+
+```liquid
+{% include writing-comments.html %}
+```
+
+To use comments on future writing pages, add the same include near the end of the article content.
+
+Configuration lives in `_config.yml`:
+
+```yml
+comments:
+  provider: disqus
+  disqus_shortname: haossr-github-io
+```
+
+If your Disqus shortname is different, update `comments.disqus_shortname`.
+You can disable comments per page with front matter: `comments: false`.
+
 ## Local development
 
 On macOS, the system Ruby can be too old for the repo's locked bundler and may cause gem install issues.

--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,13 @@ footer-links:
 
 # Enter your Disqus shortname (not your username) to enable commenting on posts
 # You can find your shortname on the Settings page of your Disqus account
+# This site's writing pages use `site.comments.disqus_shortname` (see _includes/writing-comments.html).
+# Change the value below if your Disqus shortname differs.
 disqus:
+
+comments:
+  provider: disqus
+  disqus_shortname: haossr-github-io
 
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
 google_analytics: UA-180322865-1

--- a/_includes/writing-comments.html
+++ b/_includes/writing-comments.html
@@ -1,0 +1,64 @@
+{% if page.comments != false %}
+<style>
+  .writing-comments {
+    margin-top: 34px;
+    padding-top: 22px;
+    border-top: 1px solid #e5e7eb;
+  }
+  .writing-comments-title {
+    margin: 0 0 6px;
+    font-size: 26px;
+    line-height: 1.25;
+    color: #111827;
+  }
+  .writing-comments-note {
+    margin: 0 0 16px;
+    color: #6b7280;
+    font-size: 15px;
+    line-height: 1.5;
+  }
+  .writing-comments-thread {
+    border-radius: 10px;
+    background: #fafafa;
+    padding: 2px 6px;
+  }
+  @media (max-width: 900px) {
+    .writing-comments-title { font-size: 24px; }
+  }
+  @media (max-width: 600px) {
+    .writing-comments {
+      margin-top: 28px;
+      padding-top: 18px;
+    }
+    .writing-comments-title { font-size: 22px; }
+    .writing-comments-note { font-size: 14px; }
+  }
+</style>
+
+<section class="writing-comments" aria-label="Comments">
+  <h3 class="writing-comments-title">Comments</h3>
+  <p class="writing-comments-note">Thoughts, disagreements, and edge cases welcome.</p>
+  <div id="disqus_thread" class="writing-comments-thread"></div>
+  <noscript>Please enable JavaScript to view comments powered by Disqus.</noscript>
+</section>
+
+<script>
+  (function () {
+    var shortname = '{{ site.comments.disqus_shortname | default: "haossr-github-io" }}';
+    if (!shortname) return;
+
+    window.disqus_config = function () {
+      this.page.url = '{{ page.url | absolute_url }}';
+      this.page.identifier = '{{ page.url }}';
+      this.page.title = '{{ page.title | default: "Writing" | escape }}';
+    };
+
+    var d = document;
+    var s = d.createElement('script');
+    s.src = 'https://' + shortname + '.disqus.com/embed.js';
+    s.setAttribute('data-timestamp', Date.now().toString());
+    s.async = true;
+    (d.head || d.body).appendChild(s);
+  })();
+</script>
+{% endif %}

--- a/writing/the-real-flywheel/index.html
+++ b/writing/the-real-flywheel/index.html
@@ -1,5 +1,6 @@
 ---
 layout: null
+title: The Real Flywheel
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -226,6 +227,7 @@ layout: null
         </ul>
       </details>
 
+      {% include writing-comments.html %}
     </article>
   </div>
 


### PR DESCRIPTION
## Summary
- inspected https://ysymyth.github.io/The-Second-Half/ source and confirmed it uses **Disqus** (`disqus_shortname` + embed script)
- added a reusable include `_includes/writing-comments.html` that embeds Disqus with clean, lightweight styling
- integrated the include into `writing/the-real-flywheel/index.html`
- added comments config defaults in `_config.yml` under `comments.disqus_shortname` (set to `haossr-github-io`)
- documented where to change setup values in `README.md`

## Validation
- `bundle exec jekyll build` (with Ruby 3.2 path) ✅
- `npm run test:e2e` ✅ (7 passed)

## Notes
- To disable comments on a specific page, set front matter: `comments: false`.
