### PR TITLE
Copy: tweak post-training team phrase

### DIFF
--- a/writing/the-real-flywheel/index.html
+++ b/writing/the-real-flywheel/index.html
@@ -151,7 +151,7 @@ title: The Real Flywheel
       <h1 class="essay-title">The Real Flywheel</h1>
       <p class="tldr-line"><strong>TL;DR:</strong> A flywheel that needs humans to spin it is a treadmill. A coding agent is not.</p>
 
-      <p>Almost a year ago, right after my post-training team shipped several major GPT‑4o updates, I felt exhausted — excited, but oddly disoriented.</p>
+      <p>Almost a year ago, right after my team (post-training) shipped several major GPT‑4o updates, I felt exhausted — excited, but oddly disoriented.</p>
       <p>DAU looked great. The holdout set showed an upper single-digit lift. In any normal product org, that’s champagne.</p>
       <p>And we had, in a sense, found what search / recommendation / ads people have always treated as the holy grail: a large user base; a plausible story for turning behavior into training signal; and a crew of MLEs who could stack endless small wins until the metrics moved.</p>
       <p>But it still wasn’t AGI. It was the old comfortable paradigm. The wins didn’t compound into a capability jump; the curve could flatten at any moment.</p>


### PR DESCRIPTION
Replace "my post-training team" with "my team (post-training)" in The Real Flywheel.