### PR TITLE
fix: guard Disqus embed and require real shortname

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ Configuration lives in `_config.yml`:
 ```yml
 comments:
   provider: disqus
-  disqus_shortname: haossr-github-io
+  disqus_shortname: "<your-disqus-shortname>"
 ```
 
-If your Disqus shortname is different, update `comments.disqus_shortname`.
+Set `comments.disqus_shortname` to the exact Disqus **forum shortname** from
+`https://disqus.com/admin/settings/general/` (not your username or domain).
+
 You can disable comments per page with front matter: `comments: false`.
 
 ## Local development

--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,9 @@ disqus:
 
 comments:
   provider: disqus
-  disqus_shortname: haossr-github-io
+  # Set this to your real Disqus forum shortname from https://disqus.com/admin/settings/general/
+  # Example: https-ysymyth-github-io-blog
+  disqus_shortname: ""
 
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
 google_analytics: UA-180322865-1

--- a/_includes/writing-comments.html
+++ b/_includes/writing-comments.html
@@ -1,4 +1,5 @@
 {% if page.comments != false %}
+{% assign disqus_shortname = site.comments.disqus_shortname | default: site.disqus.shortname | default: site.disqus_shortname %}
 <style>
   .writing-comments {
     margin-top: 34px;
@@ -38,14 +39,19 @@
 <section class="writing-comments" aria-label="Comments">
   <h3 class="writing-comments-title">Comments</h3>
   <p class="writing-comments-note">Thoughts, disagreements, and edge cases welcome.</p>
+
+  {% if disqus_shortname and disqus_shortname != '' %}
   <div id="disqus_thread" class="writing-comments-thread"></div>
   <noscript>Please enable JavaScript to view comments powered by Disqus.</noscript>
+  {% else %}
+  <p class="writing-comments-note">Comments are temporarily unavailable while Disqus is being configured.</p>
+  {% endif %}
 </section>
 
+{% if disqus_shortname and disqus_shortname != '' %}
 <script>
   (function () {
-    var shortname = '{{ site.comments.disqus_shortname | default: "haossr-github-io" }}';
-    if (!shortname) return;
+    var shortname = '{{ disqus_shortname }}';
 
     window.disqus_config = function () {
       this.page.url = '{{ page.url | absolute_url }}';
@@ -61,4 +67,5 @@
     (d.head || d.body).appendChild(s);
   })();
 </script>
+{% endif %}
 {% endif %}


### PR DESCRIPTION
## Summary
- Remove hardcoded fallback shortname (`haossr-github-io`) that causes Disqus error code 15
- Support reading shortname from `site.comments.disqus_shortname` (and legacy `site.disqus.shortname` / `site.disqus_shortname`)
- Only inject Disqus script when a shortname is configured
- Show a graceful "temporarily unavailable" note instead of broken Disqus iframe when shortname is missing
- Update docs/config to require exact forum shortname from Disqus admin settings

## Root cause
Current config used a placeholder/nonexistent Disqus forum shortname. Disqus embed responded with threadData code 15 ("We were unable to load Disqus").

## Validation
- `bundle exec jekyll build` (Ruby 3.2, bundler 2.7.2) passes
- Local browser sanity check at `/writing/the-real-flywheel/` shows no Disqus load error; graceful fallback message appears when shortname is unset
