### PR TITLE
fix(comments): safe re-enable with fail-closed guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,22 @@ Configuration lives in `_config.yml`:
 ```yml
 comments:
   provider: disqus
+  enabled: false
+  allowed_paths:
+    - /writing/the-real-flywheel/
   disqus_shortname: "<your-disqus-shortname>"
 ```
 
+Safety defaults are fail-closed:
+
+- `comments.enabled` must be `true`
+- the page must set front matter `comments: true`
+- the page URL must appear in `comments.allowed_paths`
+- `comments.disqus_shortname` must be a valid Disqus shortname
+
+If any check fails, the site does a graceful no-op (no Disqus runtime load).
 Set `comments.disqus_shortname` to the exact Disqus **forum shortname** from
 `https://disqus.com/admin/settings/general/` (not your username or domain).
-
-You can disable comments per page with front matter: `comments: false`.
 
 ## Local development
 

--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,11 @@ disqus:
 
 comments:
   provider: disqus
+  # Global feature flag (fail-closed by default).
+  enabled: false
+  # Explicit page allowlist (exact `page.url` values). Comments only render on these pages.
+  allowed_paths:
+    - /writing/the-real-flywheel/
   # Set this to your real Disqus forum shortname from https://disqus.com/admin/settings/general/
   # Example: https-ysymyth-github-io-blog
   disqus_shortname: ""

--- a/_includes/writing-comments.html
+++ b/_includes/writing-comments.html
@@ -1,5 +1,13 @@
-{% if page.comments != false %}
-{% assign disqus_shortname = site.comments.disqus_shortname | default: site.disqus.shortname | default: site.disqus_shortname %}
+{% assign comments_provider = site.comments.provider | default: '' | downcase %}
+{% assign comments_enabled = site.comments.enabled | default: false %}
+{% assign comments_allowed_paths = site.comments.allowed_paths | default: empty %}
+{% assign disqus_shortname = site.comments.disqus_shortname | default: site.disqus.shortname | default: site.disqus_shortname | to_s | strip %}
+{% assign page_url = page.url | to_s %}
+{% assign page_comments_opt_in = page.comments == true %}
+{% assign page_in_allowlist = comments_allowed_paths contains page_url %}
+{% assign should_render_comments = comments_enabled and page_comments_opt_in and page_in_allowlist and comments_provider == 'disqus' %}
+
+{% if should_render_comments %}
 <style>
   .writing-comments {
     margin-top: 34px;
@@ -40,18 +48,23 @@
   <h3 class="writing-comments-title">Comments</h3>
   <p class="writing-comments-note">Thoughts, disagreements, and edge cases welcome.</p>
 
-  {% if disqus_shortname and disqus_shortname != '' %}
-  <div id="disqus_thread" class="writing-comments-thread"></div>
+  <p id="comments-unavailable" class="writing-comments-note">Comments are temporarily unavailable.</p>
+  <div id="disqus_thread" class="writing-comments-thread" hidden></div>
   <noscript>Please enable JavaScript to view comments powered by Disqus.</noscript>
-  {% else %}
-  <p class="writing-comments-note">Comments are temporarily unavailable while Disqus is being configured.</p>
-  {% endif %}
 </section>
 
-{% if disqus_shortname and disqus_shortname != '' %}
 <script>
   (function () {
-    var shortname = '{{ disqus_shortname }}';
+    var shortname = '{{ disqus_shortname | escape }}';
+    var validShortnamePattern = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+    if (!validShortnamePattern.test(shortname)) return;
+
+    var unavailable = document.getElementById('comments-unavailable');
+    var thread = document.getElementById('disqus_thread');
+    if (!thread) return;
+
+    thread.hidden = false;
+    if (unavailable) unavailable.hidden = true;
 
     window.disqus_config = function () {
       this.page.url = '{{ page.url | absolute_url }}';
@@ -64,8 +77,11 @@
     s.src = 'https://' + shortname + '.disqus.com/embed.js';
     s.setAttribute('data-timestamp', Date.now().toString());
     s.async = true;
+    s.onerror = function () {
+      thread.hidden = true;
+      if (unavailable) unavailable.hidden = false;
+    };
     (d.head || d.body).appendChild(s);
   })();
 </script>
-{% endif %}
 {% endif %}

--- a/tests/comments.spec.js
+++ b/tests/comments.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('writing comments fail-closed defaults', () => {
+  test('does not render or load Disqus when comments are globally disabled', async ({ page, baseURL }) => {
+    let disqusRequests = 0;
+    const disqusErrors = [];
+
+    page.on('request', (request) => {
+      if (request.url().includes('.disqus.com/embed.js')) {
+        disqusRequests += 1;
+      }
+    });
+
+    page.on('console', (msg) => {
+      if (msg.type() !== 'error') return;
+      const text = msg.text().toLowerCase();
+      if (text.includes('disqus') || text.includes('comments')) {
+        disqusErrors.push(msg.text());
+      }
+    });
+
+    page.on('pageerror', (error) => {
+      const text = String(error).toLowerCase();
+      if (text.includes('disqus') || text.includes('comments')) {
+        disqusErrors.push(String(error));
+      }
+    });
+
+    await page.goto(`${baseURL}/writing/the-real-flywheel/`);
+
+    await expect(page.locator('section[aria-label="Comments"]')).toHaveCount(0);
+    expect(disqusRequests).toBe(0);
+    expect(disqusErrors).toEqual([]);
+  });
+});

--- a/writing/the-real-flywheel/index.html
+++ b/writing/the-real-flywheel/index.html
@@ -1,6 +1,7 @@
 ---
 layout: null
 title: The Real Flywheel
+comments: true
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -226,6 +227,7 @@ title: The Real Flywheel
         </ul>
       </details>
 
+      {% include writing-comments.html %}
     </article>
   </div>
 


### PR DESCRIPTION
## Summary
- re-enable `{% include writing-comments.html %}` on `writing/the-real-flywheel` behind strict fail-closed guards
- require **all** of the following before rendering comments:
  - `comments.enabled: true`
  - page front matter `comments: true`
  - page URL in `comments.allowed_paths`
  - provider is `disqus`
- add runtime shortname validation (strict pattern) and graceful fallback note
- add Playwright regression test to ensure default config does not render/load Disqus
- document the new comment safety model in README

## Why
Prior incident was caused by invalid Disqus shortname + eager runtime load. This patch makes comment rendering explicit and fail-closed to prevent accidental runtime failures.

## Validation
- `npm run test:e2e` ✅ (8/8 passing)
- Local static preview checks:
  1. **Default (disabled)**: no comments section, no Disqus requests, no comment-related runtime errors ✅
  2. **Enabled + valid shortname (`disqus`)**: comments section rendered, embed request issued, no runtime errors ✅
  3. **Enabled + invalid shortname (`bad.shortname`)**: graceful no-op (fallback message), zero embed requests, no runtime errors ✅
